### PR TITLE
Add structured memory system

### DIFF
--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -23,7 +23,7 @@ User Message
          │
          ▼
 ┌──────────────────┐
-│ Memory Retrieval │  Fetch relevant past context (future)
+│ Memory Retrieval │  Score + fetch top-5 relevant memories → ctx.retrieved_memories
 └────────┬─────────┘
          │
          ▼
@@ -38,10 +38,12 @@ User Message
          │          ├── CrisisBrain (deterministic, no LLM)
          │          └── CompanionBrain → LLMProvider → OpenAI
          ▼
-   Response + Persist
+   Response + Persist (messages + memories in same transaction)
 ```
 
-Memory retrieval and tool execution are scaffolded but not yet implemented. **Safety classification, mode selection, crisis bypass, sticky post-crisis cooldown, and real LLM generation via `CompanionBrain` are all live.**
+**Live**: Safety classification, mode selection, crisis bypass, sticky post-crisis cooldown, real LLM generation, memory extraction and retrieval.
+
+**Future**: Tool execution, orchestrator.
 
 ### Post-Crisis Cooldown (Sticky Safety State)
 
@@ -97,9 +99,9 @@ class ExecutionContext(BaseModel):
     user_id: Optional[str]
     conversation_id: Optional[str]
     message_content: str
-    response_mode: ResponseMode          # defaults to REFLECT
-    retrieved_memories: List[Dict]       # populated by memory layer
-    tool_results: List[Dict]             # populated by tool executor
+    response_mode: ResponseMode          # set by safety layer
+    retrieved_memories: List[Dict]       # set by memory layer [{category, content}, ...]
+    tool_results: List[Dict]             # populated by tool executor (future)
     metadata: Dict[str, Any]
 ```
 
@@ -141,7 +143,7 @@ class Tool(ABC):                  # Implement this to add a new tool
 class Brain(ABC):
     async def generate(ctx: ExecutionContext) -> str
 
-class CompanionBrain(Brain):   # mode-aware: sends per-mode system prompt to LLM
+class CompanionBrain(Brain):   # mode-aware: per-mode system prompt + memory context
 class CrisisBrain(Brain):      # deterministic: returns hardcoded 988 response, no LLM
 ```
 
@@ -160,6 +162,19 @@ Maps `ResponseMode` → `Brain`:
 | `plan` | Structured, goal-oriented, breaks problems into steps |
 | `grounding` | Calm, concise sensory/breathing exercises |
 
+If `ctx.retrieved_memories` is non-empty, a context block is appended to the system prompt:
+
+```
+Context from previous conversations with this person:
+- [dealing with] stressed about work pressure
+- [copes by] journaling helps
+- [preference] prefers: just listen
+
+Use this context naturally. Do not announce that you remember it.
+```
+
+The block is silent — it informs tone and framing without the model saying "I remember you said...".
+
 ### LLM Provider (`core/llm/`)
 
 ```python
@@ -170,7 +185,7 @@ class OpenAIProvider(LLMProvider):  # wraps openai.AsyncOpenAI
     def __init__(api_key, default_model)
 ```
 
-The provider is configured in `config.py` (`openai_api_key`, `openai_model`) and instantiated in the conversation route. Swapping the provider later requires no changes to any Brain.
+The provider is configured in `config.py` (`openai_api_key`, `openai_model`) and instantiated in the conversation route. Swapping the provider requires no changes to any Brain.
 
 ### Safety Service (`services/safety.py`)
 
@@ -191,7 +206,91 @@ class SafetyService:
 
 **Mapping**: `low→reflect`, `medium→vent`, `high→grounding`, `critical→crisis`
 
-**Pipeline behavior**: HIGH/CRITICAL log a `SafetyEvent` to the DB. CRITICAL bypasses LLM generation entirely.
+**Pipeline behavior**: MEDIUM/HIGH/CRITICAL log a `SafetyEvent` to the DB. CRITICAL bypasses LLM and memory extraction entirely.
+
+---
+
+## Memory System
+
+### Overview
+
+`MemoryService` (`services/memory.py`) extracts durable per-user facts from messages, persists them to the `user_memories` table, and retrieves relevant context before each response. All extraction is deterministic regex — no ML dependency.
+
+The memory pipeline runs on every non-crisis message:
+1. **Retrieve** — scored memories injected into `ExecutionContext` before brain generation
+2. **Extract** — new facts parsed from the user's message after generation
+3. **Persist** — new facts written to DB in the same transaction as the messages
+
+Crisis messages (`ResponseMode.CRISIS`) skip both retrieval injection and extraction to keep that path purely deterministic.
+
+### Memory Categories
+
+| Category | What it stores | Example |
+|---|---|---|
+| `stressor` | Things causing distress | `"stressed about work pressure"` |
+| `coping` | Activities / strategies that help | `"journaling helps"` |
+| `preference` | How they want to be treated | `"prefers: just listen"` |
+| `goal` | Things they're working toward | `"trying to sleep better"` |
+| `support_need` | What kind of support they want | `"needs to vent, not be fixed"` |
+| `personal_context` | Factual identity info | `"occupation: nurse"`, `"has two kids"` |
+
+### Extraction Rules (v1)
+
+26 compiled regex patterns, applied per message with `re.IGNORECASE`. All patterns require `confidence >= 0.70` to keep a fact.
+
+| Category | Pattern examples | Confidence |
+|---|---|---|
+| `stressor` | "stressed/overwhelmed/anxious about X", "struggling with X", "my [thing] has been hard" | 0.75–0.85 |
+| `coping` | "[gerund] helps me", "I find X calming", "when I X, I feel better" | 0.75–0.85 |
+| `preference` | "I prefer you to X", "please don't X", "I don't want you to X" | 0.80–0.85 |
+| `goal` | "I'm trying to X", "my goal is X", "I really want to X" | 0.75–0.85 |
+| `support_need` | "need to vent", "not looking for advice", "need someone to listen" | 0.80–0.90 |
+| `personal_context` | "I'm a [nurse/teacher/...]", "I work as X", "I have N kids", "I live alone" | 0.85–0.90 |
+
+`personal_context` uses a fixed profession allowlist to avoid extracting vague or unwanted identity claims.
+
+A `keywords` list is extracted from each fact's content by tokenising, lowercasing, removing stop words, and keeping words ≥ 3 chars. This list drives retrieval scoring.
+
+### Deduplication
+
+Before inserting a new fact, `persist_memories` loads all active memories for the user and checks for duplicates:
+
+```
+same category + keyword overlap ratio >= 50%  →  reinforce (increment times_reinforced, update last_reinforced_at)
+otherwise  →  insert as new row
+```
+
+This means "work stress" observed on multiple days accumulates a reinforcement count rather than creating duplicate rows.
+
+### Retrieval Scoring
+
+`retrieve_memories(user_id, query, db, limit=5)` loads all active memories and scores each:
+
+```
+score = (keyword_overlap × 2.0) + (recency × 1.0) + (reinforcement × 0.5)
+```
+
+| Component | Formula | Range |
+|---|---|---|
+| `keyword_overlap` | `len(memory_keywords ∩ query_keywords)` | 0–N |
+| `recency` | `max(0, 1 - days_since_reinforced / 30)` | 0.0–1.0 |
+| `reinforcement` | `min(times_reinforced / 5, 1.0)` | 0.0–1.0 |
+
+Top 5 by score are returned as `[{"category": ..., "content": ...}]` and placed into `ctx.retrieved_memories`. No minimum threshold — new users with few memories still get their best available context.
+
+### UserMemory Model (`db/models/user_memory.py`)
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | |
+| `user_id` | UUID FK → users | CASCADE delete, indexed |
+| `category` | VARCHAR(50) | One of 6 categories above |
+| `content` | TEXT | Human-readable fact |
+| `keywords` | TEXT | JSON array of significant words |
+| `source_message_id` | UUID FK → messages | Nullable, SET NULL on delete — provenance only |
+| `times_reinforced` | INTEGER | Incremented on re-observation |
+| `last_reinforced_at` | DATETIME(tz) | Used for recency scoring |
+| `is_active` | BOOLEAN | Soft delete (supports future "forget this" feature) |
 
 ---
 
@@ -213,10 +312,16 @@ All models inherit from `TimestampedBase` which provides `created_at` and `updat
 | `Conversation` | `conversations` | `user` (many-to-one), `messages` (one-to-many, cascade) |
 | `Message` | `messages` | `conversation` (many-to-one), `safety_events` (one-to-many, cascade) |
 | `SafetyEvent` | `safety_events` | `message` (many-to-one, nullable), `user` (many-to-one) |
+| `UserMemory` | `user_memories` | `user` (many-to-one, cascade) |
 
 ### Migrations
 
 Managed via Alembic with the async template. `render_as_batch=True` is enabled for SQLite compatibility. Run `alembic upgrade head` from the `backend/` directory.
+
+| Revision | Description |
+|---|---|
+| `34da07402df8` | Initial schema: users, conversations, messages, safety_events |
+| `2b8f7a3e9c15` | Add user_memories table |
 
 ---
 
@@ -297,7 +402,6 @@ All authenticated requests go through `api.authGet` / `api.authPost` which read 
 
 ## Current Status
 
-**Completed**: Auth (E2E), Database (Alembic + SQLite), Conversation CRUD (frontend + backend), Execution architecture scaffolding, Safety risk classifier with mode selection, crisis bypass, sticky post-crisis cooldown, safety event logging, **LLM response generation via `CompanionBrain`/`CrisisBrain` with OpenAI**, and crisis-aware frontend UI.
+**Completed**: Auth (E2E), Database (Alembic + SQLite), Conversation CRUD (frontend + backend), Execution architecture scaffolding, Safety risk classifier with mode selection, crisis bypass, sticky post-crisis cooldown, safety event logging, LLM response generation via `CompanionBrain`/`CrisisBrain` with OpenAI, crisis-aware frontend UI, **structured memory system** (extraction, deduplication, retrieval scoring, `ExecutionContext` injection, `CompanionBrain` prompt integration).
 
-**Next up**: Pass conversation history into the LLM context (currently only the most recent user message is sent), then implement memory retrieval into `ctx.retrieved_memories`.
-
+**Next up**: Pass conversation history into the LLM context (currently only the most recent user message is sent). Then wire the Tool system and build the orchestrator.

--- a/backend/alembic/versions/2b8f7a3e9c15_add_user_memories.py
+++ b/backend/alembic/versions/2b8f7a3e9c15_add_user_memories.py
@@ -1,0 +1,53 @@
+"""Add user_memories table
+
+Revision ID: 2b8f7a3e9c15
+Revises: 34da07402df8
+Create Date: 2026-05-04 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '2b8f7a3e9c15'
+down_revision: Union[str, Sequence[str], None] = '34da07402df8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'user_memories',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('category', sa.String(length=50), nullable=False),
+        sa.Column('content', sa.Text(), nullable=False),
+        sa.Column('keywords', sa.Text(), nullable=False),
+        sa.Column('source_message_id', sa.UUID(), nullable=True),
+        sa.Column('times_reinforced', sa.Integer(), nullable=False),
+        sa.Column('last_reinforced_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['user_id'], ['users.id'],
+            name=op.f('fk_user_memories_user_id_users'),
+            ondelete='CASCADE',
+        ),
+        sa.ForeignKeyConstraint(
+            ['source_message_id'], ['messages.id'],
+            name=op.f('fk_user_memories_source_message_id_messages'),
+            ondelete='SET NULL',
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_user_memories')),
+    )
+    with op.batch_alter_table('user_memories', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_user_memories_user_id'), ['user_id'], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('user_memories', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_user_memories_user_id'))
+    op.drop_table('user_memories')

--- a/backend/src/core/brains/companion.py
+++ b/backend/src/core/brains/companion.py
@@ -9,8 +9,8 @@ from src.config import settings
 
 logger = logging.getLogger(__name__)
 
-# Very simple v1 system prompts mapped by ResponseMode
-SYSTEM_PROMPTS: Dict[ResponseMode, str] = {
+# Base system prompts by response mode
+_BASE_PROMPTS: Dict[ResponseMode, str] = {
     ResponseMode.REFLECT: (
         "You are a supportive, empathetic companion. Listen carefully to the user's message. "
         "Reflect back their feelings to show you understand, and ask a gentle question to explore further. "
@@ -18,7 +18,7 @@ SYSTEM_PROMPTS: Dict[ResponseMode, str] = {
     ),
     ResponseMode.VENT: (
         "You are an active listener holding space for the user to vent. "
-        "Validate their emotions strongly. Do NOT offer unprompted advice or trying to fix it immediately. "
+        "Validate their emotions strongly. Do NOT offer unprompted advice or try to fix it immediately. "
         "Keep your response concise and supportive."
     ),
     ResponseMode.PLAN: (
@@ -32,38 +32,70 @@ SYSTEM_PROMPTS: Dict[ResponseMode, str] = {
     ),
 }
 
+# Category labels shown in the memory block
+_CATEGORY_LABELS: Dict[str, str] = {
+    "stressor": "dealing with",
+    "coping": "copes by",
+    "preference": "preference",
+    "goal": "working toward",
+    "support_need": "support style",
+    "personal_context": "about them",
+}
+
+
+def _build_memory_block(memories: list[dict]) -> str:
+    """
+    Format retrieved memories as a compact context block appended to the
+    system prompt. Empty list returns an empty string (no block added).
+    """
+    if not memories:
+        return ""
+
+    lines = []
+    for m in memories:
+        label = _CATEGORY_LABELS.get(m.get("category", ""), m.get("category", ""))
+        content = m.get("content", "").strip()
+        if content:
+            lines.append(f"- [{label}] {content}")
+
+    if not lines:
+        return ""
+
+    return (
+        "\n\nContext from previous conversations with this person:\n"
+        + "\n".join(lines)
+        + "\n\nUse this context naturally. Do not announce that you remember it. "
+        "Let it quietly inform your empathy, your questions, and how you frame things."
+    )
+
+
 class CompanionBrain(Brain):
     """Brain that uses an LLMProvider to generate responses tailored to the active response mode."""
 
     def __init__(self, provider: LLMProvider):
-        """Initialize the CompanionBrain.
-        
-        Args:
-            provider: The LLMProvider to use for generating text.
-        """
         self.provider = provider
-        
+
     async def generate(self, ctx: ExecutionContext) -> str:
-        """Generate an LLM response based on the execution context and mode."""
-        # Get the appropriate system prompt, fallback to REFLECT if missing
-        system_prompt = SYSTEM_PROMPTS.get(ctx.response_mode, SYSTEM_PROMPTS[ResponseMode.REFLECT])
-        
-        # Build message payload
+        base_prompt = _BASE_PROMPTS.get(ctx.response_mode, _BASE_PROMPTS[ResponseMode.REFLECT])
+        memory_block = _build_memory_block(ctx.retrieved_memories)
+        system_prompt = base_prompt + memory_block
+
         messages = [
             {"role": "system", "content": system_prompt},
-            {"role": "user", "content": ctx.message_content}
+            {"role": "user", "content": ctx.message_content},
         ]
-        
-        logger.info(f"CompanionBrain generating response in {ctx.response_mode} mode")
-        
-        # Call provider (model name comes from settings, passed here or handled by router setup)
-        # We fetch it from settings directly here for simplicity since we don't have a complex orchestrator yet
+
+        logger.info(
+            f"CompanionBrain generating | mode={ctx.response_mode.value} "
+            f"memories={len(ctx.retrieved_memories)}"
+        )
+
         try:
             content = await self.provider.complete(
                 messages=messages,
                 model=settings.openai_model,
                 temperature=0.7,
-                max_tokens=300
+                max_tokens=300,
             )
             return content.strip()
         except Exception as e:

--- a/backend/src/db/models/__init__.py
+++ b/backend/src/db/models/__init__.py
@@ -3,5 +3,6 @@ from src.db.models.user import User
 from src.db.models.conversation import Conversation
 from src.db.models.message import Message
 from src.db.models.safety_event import SafetyEvent
+from src.db.models.user_memory import UserMemory
 
-__all__ = ["User", "Conversation", "Message", "SafetyEvent"]
+__all__ = ["User", "Conversation", "Message", "SafetyEvent", "UserMemory"]

--- a/backend/src/db/models/user_memory.py
+++ b/backend/src/db/models/user_memory.py
@@ -1,0 +1,39 @@
+"""UserMemory ORM model — stores durable per-user facts extracted from conversations."""
+from uuid import uuid4
+from datetime import datetime
+from sqlalchemy import String, ForeignKey, Text, UUID, Integer, Boolean, DateTime
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from src.db.base import TimestampedBase
+
+
+class UserMemory(TimestampedBase):
+    __tablename__ = "user_memories"
+
+    id: Mapped[str] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    # stressor | coping | preference | goal | support_need | personal_context
+    category: Mapped[str] = mapped_column(String(50), nullable=False)
+    # Human-readable memory string, e.g. "stressed about work pressure"
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    # JSON array of significant words used for keyword-based retrieval scoring
+    keywords: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    # Nullable traceability link — not cascade-deleted if message is removed
+    source_message_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("messages.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Incremented each time the same fact is re-observed (deduplication)
+    times_reinforced: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    last_reinforced_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+    # Soft delete — allows future "forget this" feature without losing audit trail
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    user = relationship("User")

--- a/backend/src/routes/conversations.py
+++ b/backend/src/routes/conversations.py
@@ -19,6 +19,7 @@ from src.core.context.execution import ExecutionContext, ResponseMode
 from src.core.llm.openai_provider import OpenAIProvider
 from src.core.brains.router import BrainRouter
 from src.services.safety import SafetyService, RiskLevel
+from src.services.memory import MemoryService
 from src.config import settings
 from src.logging_config import logger
 
@@ -199,13 +200,25 @@ async def send_message(
     else:
         actual_mode = classifier_mode
 
+    # Retrieve relevant memories (skipped during crisis — deterministic path only)
+    memory_service = MemoryService()
+    retrieved_memories: list[dict] = []
+    if actual_mode != ResponseMode.CRISIS:
+        retrieved_memories = await memory_service.retrieve_memories(
+            user_id=str(user.id),
+            query=user_msg.content,
+            db=db,
+            limit=5,
+        )
+
     # Build the execution context
     ctx = ExecutionContext(
         session_id=str(user.id),
         user_id=str(user.id),
         conversation_id=str(conversation.id),
         message_content=user_msg.content,
-        response_mode=actual_mode
+        response_mode=actual_mode,
+        retrieved_memories=retrieved_memories,
     )
 
     # Log safety events to DB for elevated risk levels OR if we're in elevated state
@@ -247,6 +260,19 @@ async def send_message(
         content=reply_content,
     )
     db.add(assistant_msg)
+
+    # Extract and persist memories from this user message (never from crisis messages)
+    if actual_mode != ResponseMode.CRISIS:
+        facts = memory_service.extract_from_message(
+            content=user_msg.content,
+            source_message_id=str(user_msg.id),
+        )
+        if facts:
+            await memory_service.persist_memories(
+                user_id=str(user.id),
+                facts=facts,
+                db=db,
+            )
 
     await db.commit()
     await db.refresh(user_msg)

--- a/backend/src/services/memory.py
+++ b/backend/src/services/memory.py
@@ -1,40 +1,463 @@
 """Memory Engine service.
 
 Responsible for:
-- Extracting structured memories from conversations
-- Storing memories (recurring stressors, coping strategies, preferences)
-- Retrieving relevant memories for context
+- Extracting structured memories from user messages (rule-based, deterministic)
+- Persisting memories with deduplication (reinforcement counting)
+- Retrieving relevant memories via keyword + recency scoring
 """
 
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID as _UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from src.db.models.user_memory import UserMemory
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Stop words — excluded from keyword indexing
+# ---------------------------------------------------------------------------
+_STOP_WORDS: frozenset[str] = frozenset({
+    "i", "me", "my", "myself", "we", "our", "you", "your", "he", "she", "it",
+    "they", "them", "their", "what", "which", "who", "this", "that", "these",
+    "those", "am", "is", "are", "was", "were", "be", "been", "being", "have",
+    "has", "had", "do", "does", "did", "will", "would", "could", "should",
+    "may", "might", "shall", "can", "need", "a", "an", "the", "and", "but",
+    "or", "nor", "for", "yet", "so", "as", "at", "by", "from", "in", "into",
+    "of", "on", "to", "up", "with", "about", "after", "before", "through",
+    "just", "very", "really", "also", "not", "no", "its", "too", "than",
+    "then", "when", "how", "all", "both", "few", "more", "most", "other",
+    "some", "such", "only", "same", "own", "if", "because", "while",
+    "although", "though", "since", "again", "here", "there", "where", "why",
+    "any", "each", "every", "get", "got", "feel", "felt", "think", "thought",
+    "know", "knew", "like", "make", "made", "much", "many", "little", "lot",
+    "something", "anything", "nothing", "everything", "someone", "anyone",
+    "always", "never", "sometimes", "often", "usually", "already", "still",
+    "bit", "now", "day", "days", "time", "today", "going", "thing", "things",
+})
+
+
+# ---------------------------------------------------------------------------
+# MemoryFact — intermediate representation before DB persistence
+# ---------------------------------------------------------------------------
+@dataclass
+class MemoryFact:
+    """A single extracted memory, ready to be persisted or scored."""
+    category: str
+    content: str
+    keywords: list[str]
+    confidence: float
+    source_message_id: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+def _cap(m: re.Match, group: int = 1, max_len: int = 100) -> str:
+    """Capture a regex group, strip trailing punctuation/spaces, enforce length."""
+    text = m.group(group).strip().rstrip(".,!? ").lower()
+    return text[:max_len]
+
+
+def _keywords(text: str) -> list[str]:
+    """Tokenise text into significant lowercase words, excluding stop words."""
+    tokens = re.findall(r"[a-z]+", text.lower())
+    return sorted({t for t in tokens if len(t) >= 3 and t not in _STOP_WORDS})
+
+
+# ---------------------------------------------------------------------------
+# Extraction rules
+# Each tuple: (compiled_pattern, content_fn, category, confidence)
+# Patterns are case-insensitive. content_fn receives the Match and returns
+# the human-readable memory string.
+# ---------------------------------------------------------------------------
+_RULES: list[tuple[re.Pattern, any, str, float]] = []
+
+_RAW_RULES: list[tuple[str, any, str, float]] = [
+
+    # ── STRESSORS ────────────────────────────────────────────────────────
+    # "stressed / overwhelmed / anxious / worried about X"
+    (
+        r"\b(stressed\s+(?:out\s+)?|overwhelmed\s+|anxious\s+|worried\s+)(?:about|over|by)\s+(.{4,70})",
+        lambda m: f"stressed about {_cap(m, 2)}",
+        "stressor", 0.85,
+    ),
+    # "struggling with X"
+    (
+        r"\bstruggling\s+with\s+(.{4,60})",
+        lambda m: f"struggling with {_cap(m)}",
+        "stressor", 0.80,
+    ),
+    # "my [job/work/relationship/etc.] has been [stressful/hard/...]"
+    (
+        r"\bmy\s+(\w+(?:\s+\w+)?)\s+(?:has been|is|keeps being|was|keeps)\s+"
+        r"(?:really\s+|so\s+|very\s+)?(?:stressful|overwhelming|exhausting|difficult|hard|rough)\b",
+        lambda m: f"stressed about {_cap(m)}",
+        "stressor", 0.75,
+    ),
+    # "can't stop thinking / worrying about X"
+    (
+        r"\bcan't\s+stop\s+(?:thinking|worrying)\s+about\s+(.{4,60})",
+        lambda m: f"preoccupied with {_cap(m)}",
+        "stressor", 0.80,
+    ),
+    # "been dealing with X" / "been going through X"
+    (
+        r"\b(?:been\s+)?(?:dealing|going through)\s+(?:a\s+lot\s+with\s+|with\s+)(.{4,60})",
+        lambda m: f"dealing with {_cap(m)}",
+        "stressor", 0.75,
+    ),
+
+    # ── COPING STRATEGIES ────────────────────────────────────────────────
+    # "[gerund phrase] helps me" — gerund ensures it's an activity, not a person
+    (
+        r"\b(\w+ing(?:\s+(?:for\s+)?\w+){0,3})\s+(?:really\s+|always\s+)?helps?\s+me\b",
+        lambda m: f"{_cap(m)} helps",
+        "coping", 0.80,
+    ),
+    # "I find [X] calming / helpful / relaxing"
+    (
+        r"\bI\s+find\s+(.{4,50}?)\s+(?:calming|helpful|relaxing|soothing|grounding|comforting)\b",
+        lambda m: f"finds {_cap(m)} calming",
+        "coping", 0.85,
+    ),
+    # "when I [do X], I feel better / calmer"
+    (
+        r"\bwhen\s+I\s+(.{4,50}?),\s+I\s+(?:feel|get)\s+(?:better|calmer|less anxious|more settled)\b",
+        lambda m: f"{_cap(m)} helps feel better",
+        "coping", 0.80,
+    ),
+    # "X works for me" / "X helps me cope"
+    (
+        r"\b(.{4,40}?)\s+(?:works|helps?)\s+(?:for me|me cope|me deal)\b",
+        lambda m: f"{_cap(m)} helps cope",
+        "coping", 0.75,
+    ),
+
+    # ── PREFERENCES (directed at the assistant) ───────────────────────────
+    # "I prefer you to / I'd prefer you just X"
+    (
+        r"\bI\s+(?:prefer|would prefer|would rather)\s+you\s+(?:to\s+)?(?:just\s+)?(.{4,60})",
+        lambda m: f"prefers: {_cap(m)}",
+        "preference", 0.85,
+    ),
+    # "please don't X" / "please just X"
+    (
+        r"\bplease\s+(?:just\s+)?(?:don't|do not)\s+(.{4,60})",
+        lambda m: f"dislikes: {_cap(m)}",
+        "preference", 0.80,
+    ),
+    # "I don't want/like you to X"
+    (
+        r"\bI\s+don't\s+(?:want|like)\s+you\s+to\s+(.{4,60})",
+        lambda m: f"dislikes when you: {_cap(m)}",
+        "preference", 0.85,
+    ),
+
+    # ── GOALS ────────────────────────────────────────────────────────────
+    # "I'm trying / working to X"
+    (
+        r"\bI(?:'m|\s+am)\s+(?:trying|working)\s+to\s+(.{4,60})",
+        lambda m: f"trying to {_cap(m)}",
+        "goal", 0.80,
+    ),
+    # "my goal is to X"
+    (
+        r"\bmy\s+goal\s+is\s+(?:to\s+)?(.{4,60})",
+        lambda m: f"goal: {_cap(m)}",
+        "goal", 0.85,
+    ),
+    # "I really want to X" (stronger signal than plain "I want to")
+    (
+        r"\bI\s+really\s+want\s+to\s+(.{4,60})",
+        lambda m: f"wants to {_cap(m)}",
+        "goal", 0.75,
+    ),
+
+    # ── SUPPORT NEEDS ─────────────────────────────────────────────────────
+    (
+        r"\bI\s+(?:just\s+)?(?:need|want)\s+(?:to\s+)?(?:just\s+)?vent\b",
+        lambda m: "needs to vent, not be fixed",
+        "support_need", 0.90,
+    ),
+    (
+        r"\b(?:not?|don't)\s+(?:looking for|want(?:ing)?|need(?:ing)?)\s+advice\b",
+        lambda m: "not looking for advice",
+        "support_need", 0.90,
+    ),
+    (
+        r"\bI\s+(?:just\s+)?need\s+someone\s+to\s+listen\b",
+        lambda m: "needs someone to listen",
+        "support_need", 0.90,
+    ),
+    (
+        r"\bI\s+(?:just\s+)?need\s+(?:some\s+)?(?:help|support|guidance)\s+(?:figuring|planning|deciding)\b",
+        lambda m: "wants help planning or deciding",
+        "support_need", 0.80,
+    ),
+
+    # ── PERSONAL CONTEXT ─────────────────────────────────────────────────
+    # "I'm a/an [profession]" — fixed list keeps this conservative
+    (
+        r"\bI(?:'m|\s+am)\s+a(?:n)?\s+"
+        r"(teacher|nurse|doctor|student|engineer|developer|designer|manager|"
+        r"therapist|counselor|lawyer|artist|musician|chef|driver|writer|"
+        r"social worker|professor|researcher|caregiver|parent)\b",
+        lambda m: f"occupation: {_cap(m)}",
+        "personal_context", 0.90,
+    ),
+    # "I work as a/an [X]"
+    (
+        r"\bI\s+work\s+as\s+a(?:n)?\s+(\w+(?:\s+\w+)?)\b",
+        lambda m: f"occupation: {_cap(m)}",
+        "personal_context", 0.90,
+    ),
+    # "I have [N] kids / children"
+    (
+        r"\bI\s+(?:have|'ve got)\s+(\w+)\s+(?:kids?|children|daughters?|sons?)\b",
+        lambda m: f"has {_cap(m)} kids",
+        "personal_context", 0.85,
+    ),
+    # "I live alone / with my partner / with my family"
+    (
+        r"\bI\s+live\s+(alone|with\s+my\s+partner|with\s+my\s+family|with\s+roommates?|by\s+myself)\b",
+        lambda m: f"lives {_cap(m)}",
+        "personal_context", 0.85,
+    ),
+]
+
+# Compile all patterns once at import time
+for _raw_pat, _fn, _cat, _conf in _RAW_RULES:
+    _RULES.append((re.compile(_raw_pat, re.IGNORECASE), _fn, _cat, _conf))
+
+# Minimum confidence required to keep a fact
+_MIN_CONFIDENCE: float = 0.70
+
+# Keyword overlap ratio needed to consider two memories duplicates
+_DEDUP_THRESHOLD: float = 0.50
+
+# Retrieval scoring weights
+_W_KEYWORD = 2.0
+_W_RECENCY = 1.0
+_W_REINFORCEMENT = 0.5
+
+
+# ---------------------------------------------------------------------------
+# MemoryService
+# ---------------------------------------------------------------------------
 class MemoryService:
-    """Service for managing user memory and context retrieval."""
-    
-    def __init__(self):
-        """Initialize memory service."""
-        pass
-    
+    """Deterministic memory extraction and retrieval service."""
+
+    # ── Extraction ──────────────────────────────────────────────────────
+
+    def extract_from_message(
+        self,
+        content: str,
+        source_message_id: Optional[str] = None,
+    ) -> list[MemoryFact]:
+        """
+        Apply extraction rules to a single user message.
+
+        Returns a list of MemoryFacts (not yet persisted). Each fact has
+        content, category, keywords, and confidence. Facts below
+        _MIN_CONFIDENCE are discarded.
+
+        Never call this for CRISIS-mode messages — callers are responsible
+        for that guard.
+        """
+        facts: list[MemoryFact] = []
+        seen_contents: set[str] = set()  # within-message dedup
+
+        for pattern, content_fn, category, confidence in _RULES:
+            match = pattern.search(content)
+            if not match:
+                continue
+            if confidence < _MIN_CONFIDENCE:
+                continue
+
+            try:
+                fact_content = content_fn(match).strip()
+            except Exception:
+                continue
+
+            if not fact_content or fact_content in seen_contents:
+                continue
+            seen_contents.add(fact_content)
+
+            kw = _keywords(fact_content)
+            facts.append(
+                MemoryFact(
+                    category=category,
+                    content=fact_content,
+                    keywords=kw,
+                    confidence=confidence,
+                    source_message_id=source_message_id,
+                )
+            )
+
+        return facts
+
+    # ── Persistence ─────────────────────────────────────────────────────
+
+    async def persist_memories(
+        self,
+        user_id: str,
+        facts: list[MemoryFact],
+        db: AsyncSession,
+    ) -> None:
+        """
+        Persist a list of MemoryFacts for a user, with deduplication.
+
+        If an existing active memory in the same category shares >= 50%
+        keyword overlap with the new fact, we reinforce (increment counter +
+        update timestamp) instead of inserting a duplicate.
+        """
+        if not facts:
+            return
+
+        # Load all active memories for this user in one query
+        result = await db.execute(
+            select(UserMemory).where(
+                UserMemory.user_id == _UUID(user_id),
+                UserMemory.is_active.is_(True),
+            )
+        )
+        existing: list[UserMemory] = list(result.scalars().all())
+
+        now = datetime.now(timezone.utc)
+
+        for fact in facts:
+            duplicate = self._find_duplicate(fact, existing)
+            if duplicate:
+                duplicate.times_reinforced += 1
+                duplicate.last_reinforced_at = now
+                logger.debug(
+                    f"MEMORY reinforce | user={user_id} cat={fact.category} "
+                    f"content='{fact.content}' x{duplicate.times_reinforced}"
+                )
+            else:
+                memory = UserMemory(
+                    user_id=_UUID(user_id),
+                    category=fact.category,
+                    content=fact.content,
+                    keywords=json.dumps(fact.keywords),
+                    source_message_id=_UUID(fact.source_message_id) if fact.source_message_id else None,
+                    times_reinforced=1,
+                    last_reinforced_at=now,
+                    is_active=True,
+                )
+                db.add(memory)
+                existing.append(memory)  # keep local list in sync for within-batch dedup
+                logger.info(
+                    f"MEMORY new | user={user_id} cat={fact.category} "
+                    f"content='{fact.content}'"
+                )
+
+    def _find_duplicate(
+        self, fact: MemoryFact, existing: list[UserMemory]
+    ) -> Optional[UserMemory]:
+        """Return the first existing memory that duplicates this fact, or None."""
+        new_kw = set(fact.keywords)
+        if not new_kw:
+            return None
+
+        for mem in existing:
+            if mem.category != fact.category:
+                continue
+            try:
+                existing_kw = set(json.loads(mem.keywords))
+            except (json.JSONDecodeError, TypeError):
+                existing_kw = set()
+
+            if not existing_kw:
+                continue
+
+            overlap = len(new_kw & existing_kw) / min(len(new_kw), len(existing_kw))
+            if overlap >= _DEDUP_THRESHOLD:
+                return mem
+
+        return None
+
+    # ── Retrieval ───────────────────────────────────────────────────────
+
+    async def retrieve_memories(
+        self,
+        user_id: str,
+        query: str,
+        db: AsyncSession,
+        limit: int = 5,
+    ) -> list[dict]:
+        """
+        Return the most relevant active memories for a user given the current
+        message, as a list of dicts ready for injection into ExecutionContext.
+
+        Scoring (higher = more relevant):
+          keyword_overlap × 2.0   — semantic relevance to this message
+          recency_score  × 1.0   — (1 - days_old/30), capped at [0, 1]
+          reinforcement  × 0.5   — min(times_reinforced/5, 1.0)
+
+        All scored memories are returned ranked; no minimum threshold so that
+        fresh users with few memories always get their best context.
+        """
+        result = await db.execute(
+            select(UserMemory).where(
+                UserMemory.user_id == _UUID(user_id),
+                UserMemory.is_active.is_(True),
+            )
+        )
+        memories: list[UserMemory] = list(result.scalars().all())
+
+        if not memories:
+            return []
+
+        query_words = set(_keywords(query))
+        now = datetime.now(timezone.utc)
+        scored: list[tuple[float, UserMemory]] = []
+
+        for mem in memories:
+            score = self._score(mem, query_words, now)
+            scored.append((score, mem))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+
+        return [
+            {"category": mem.category, "content": mem.content}
+            for _, mem in scored[:limit]
+        ]
+
+    def _score(
+        self,
+        mem: UserMemory,
+        query_words: set[str],
+        now: datetime,
+    ) -> float:
+        try:
+            mem_kw = set(json.loads(mem.keywords))
+        except (json.JSONDecodeError, TypeError):
+            mem_kw = set()
+
+        keyword_score = len(mem_kw & query_words) * _W_KEYWORD
+
+        reinforced_at = mem.last_reinforced_at
+        if reinforced_at.tzinfo is None:
+            reinforced_at = reinforced_at.replace(tzinfo=timezone.utc)
+        days_old = max(0.0, (now - reinforced_at).total_seconds() / 86400)
+        recency_score = max(0.0, 1.0 - (days_old / 30.0)) * _W_RECENCY
+
+        reinforcement_score = min(mem.times_reinforced / 5.0, 1.0) * _W_REINFORCEMENT
+
+        return keyword_score + recency_score + reinforcement_score
+
+    # ── Legacy stubs (kept for API compatibility) ─────────────────────────
+
     async def extract_memory(self, conversation_text: str) -> dict:
-        """Extract structured memory from conversation.
-        
-        Args:
-            conversation_text: Raw conversation text
-            
-        Returns:
-            Structured memory (stressors, coping_strategies, preferences)
-        """
-        # TODO: Implement memory extraction logic
-        raise NotImplementedError("Memory extraction not yet implemented")
-    
-    async def retrieve_memories(self, query: str, limit: int = 5) -> list:
-        """Retrieve relevant memories for a query.
-        
-        Args:
-            query: Search query or context
-            limit: Maximum number of memories to return
-            
-        Returns:
-            List of relevant memories
-        """
-        # TODO: Implement memory retrieval logic
-        raise NotImplementedError("Memory retrieval not yet implemented")
+        """Deprecated — use extract_from_message() instead."""
+        facts = self.extract_from_message(conversation_text)
+        return {"facts": [{"category": f.category, "content": f.content} for f in facts]}

--- a/backend/tests/test_memory.py
+++ b/backend/tests/test_memory.py
@@ -1,0 +1,315 @@
+"""Tests for MemoryService — extraction, deduplication, and retrieval scoring.
+
+Run from backend/ with:
+    .\\venv-win\\Scripts\\Activate.ps1
+    python -m pytest tests/test_memory.py -v
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone, timedelta
+
+from src.services.memory import MemoryService, MemoryFact, _keywords
+
+
+# ── Keyword extraction ────────────────────────────────────────────────────────
+
+class TestKeywords:
+    def test_removes_stop_words(self):
+        result = _keywords("I am really stressed about my job")
+        assert "stressed" in result
+        assert "job" in result
+        assert "i" not in result
+        assert "am" not in result
+        assert "really" not in result
+        assert "my" not in result
+
+    def test_short_words_excluded(self):
+        result = _keywords("go to the gym")
+        assert "gym" in result
+        assert "go" not in result  # len 2
+
+    def test_deduplicates(self):
+        result = _keywords("work work work")
+        assert result.count("work") == 1
+
+
+# ── Extraction: stressors ─────────────────────────────────────────────────────
+
+class TestExtractStressors:
+    svc = MemoryService()
+
+    def test_stressed_about(self):
+        facts = self.svc.extract_from_message("I've been so stressed about work lately")
+        stressors = [f for f in facts if f.category == "stressor"]
+        assert len(stressors) >= 1
+        assert "work" in stressors[0].content
+
+    def test_overwhelmed_by(self):
+        facts = self.svc.extract_from_message("I'm overwhelmed by everything at home")
+        stressors = [f for f in facts if f.category == "stressor"]
+        assert len(stressors) >= 1
+
+    def test_struggling_with(self):
+        facts = self.svc.extract_from_message("I've been struggling with my anxiety for months")
+        stressors = [f for f in facts if f.category == "stressor"]
+        assert len(stressors) >= 1
+        assert "anxiety" in stressors[0].content
+
+    def test_my_job_is_stressful(self):
+        facts = self.svc.extract_from_message("My job has been really stressful lately")
+        stressors = [f for f in facts if f.category == "stressor"]
+        assert len(stressors) >= 1
+        assert "job" in stressors[0].content
+
+    def test_no_false_positive_positive_message(self):
+        facts = self.svc.extract_from_message("I had a great day today, feeling good!")
+        stressors = [f for f in facts if f.category == "stressor"]
+        assert len(stressors) == 0
+
+
+# ── Extraction: coping strategies ────────────────────────────────────────────
+
+class TestExtractCoping:
+    svc = MemoryService()
+
+    def test_gerund_helps_me(self):
+        facts = self.svc.extract_from_message("Going for walks really helps me a lot")
+        coping = [f for f in facts if f.category == "coping"]
+        assert len(coping) >= 1
+        assert "walking" in coping[0].content or "going" in coping[0].content
+
+    def test_find_calming(self):
+        facts = self.svc.extract_from_message("I find journaling really calming when I'm upset")
+        coping = [f for f in facts if f.category == "coping"]
+        assert len(coping) >= 1
+        assert "journaling" in coping[0].content
+
+    def test_when_i_feel_better(self):
+        facts = self.svc.extract_from_message("when I meditate, I feel calmer")
+        coping = [f for f in facts if f.category == "coping"]
+        assert len(coping) >= 1
+
+
+# ── Extraction: preferences ───────────────────────────────────────────────────
+
+class TestExtractPreferences:
+    svc = MemoryService()
+
+    def test_prefer_you_to(self):
+        facts = self.svc.extract_from_message("I prefer you to just listen rather than give advice")
+        prefs = [f for f in facts if f.category == "preference"]
+        assert len(prefs) >= 1
+        assert "listen" in prefs[0].content
+
+    def test_please_dont(self):
+        facts = self.svc.extract_from_message("Please don't tell me what to do right now")
+        prefs = [f for f in facts if f.category == "preference"]
+        assert len(prefs) >= 1
+
+    def test_dont_want_you_to(self):
+        facts = self.svc.extract_from_message("I don't want you to give me advice today")
+        prefs = [f for f in facts if f.category == "preference"]
+        assert len(prefs) >= 1
+
+
+# ── Extraction: goals ─────────────────────────────────────────────────────────
+
+class TestExtractGoals:
+    svc = MemoryService()
+
+    def test_trying_to(self):
+        facts = self.svc.extract_from_message("I'm trying to sleep better and reduce my stress")
+        goals = [f for f in facts if f.category == "goal"]
+        assert len(goals) >= 1
+        assert "sleep" in goals[0].content
+
+    def test_my_goal_is(self):
+        facts = self.svc.extract_from_message("My goal is to exercise more consistently")
+        goals = [f for f in facts if f.category == "goal"]
+        assert len(goals) >= 1
+
+    def test_really_want_to(self):
+        facts = self.svc.extract_from_message("I really want to get better at managing my time")
+        goals = [f for f in facts if f.category == "goal"]
+        assert len(goals) >= 1
+
+
+# ── Extraction: support needs ─────────────────────────────────────────────────
+
+class TestExtractSupportNeeds:
+    svc = MemoryService()
+
+    def test_need_to_vent(self):
+        facts = self.svc.extract_from_message("I just need to vent, I don't want advice")
+        needs = [f for f in facts if f.category == "support_need"]
+        assert len(needs) >= 1
+        assert "vent" in needs[0].content
+
+    def test_not_looking_for_advice(self):
+        facts = self.svc.extract_from_message("I'm not looking for advice, just support")
+        needs = [f for f in facts if f.category == "support_need"]
+        assert len(needs) >= 1
+
+    def test_need_someone_to_listen(self):
+        facts = self.svc.extract_from_message("I just need someone to listen right now")
+        needs = [f for f in facts if f.category == "support_need"]
+        assert len(needs) >= 1
+
+
+# ── Extraction: personal context ──────────────────────────────────────────────
+
+class TestExtractPersonalContext:
+    svc = MemoryService()
+
+    def test_occupation_im_a(self):
+        facts = self.svc.extract_from_message("I'm a nurse and work night shifts")
+        ctx = [f for f in facts if f.category == "personal_context"]
+        assert len(ctx) >= 1
+        assert "nurse" in ctx[0].content
+
+    def test_occupation_work_as(self):
+        facts = self.svc.extract_from_message("I work as a teacher at a primary school")
+        ctx = [f for f in facts if f.category == "personal_context"]
+        assert len(ctx) >= 1
+        assert "teacher" in ctx[0].content
+
+    def test_has_kids(self):
+        facts = self.svc.extract_from_message("I have two kids and it's been exhausting")
+        ctx = [f for f in facts if f.category == "personal_context"]
+        assert len(ctx) >= 1
+        assert "two" in ctx[0].content or "kids" in ctx[0].content
+
+    def test_lives_alone(self):
+        facts = self.svc.extract_from_message("I live alone and sometimes it gets really quiet")
+        ctx = [f for f in facts if f.category == "personal_context"]
+        assert len(ctx) >= 1
+        assert "alone" in ctx[0].content
+
+
+# ── Extraction: nothing from crisis-level text ────────────────────────────────
+
+class TestExtractionConservatism:
+    svc = MemoryService()
+
+    def test_no_memory_from_trivial_message(self):
+        facts = self.svc.extract_from_message("hey how are you doing today")
+        assert facts == []
+
+    def test_no_memory_from_greeting(self):
+        facts = self.svc.extract_from_message("hi")
+        assert facts == []
+
+    def test_keywords_populated(self):
+        facts = self.svc.extract_from_message("I'm struggling with anxiety at work")
+        assert all(len(f.keywords) > 0 for f in facts)
+
+    def test_confidence_meets_threshold(self):
+        facts = self.svc.extract_from_message("I'm a teacher and find mindfulness calming")
+        assert all(f.confidence >= 0.70 for f in facts)
+
+
+# ── Deduplication ─────────────────────────────────────────────────────────────
+
+class TestDeduplication:
+    svc = MemoryService()
+
+    def _make_memory(self, category, content, keywords_list):
+        m = MagicMock(spec=["category", "keywords", "times_reinforced", "last_reinforced_at"])
+        m.category = category
+        m.keywords = json.dumps(keywords_list)
+        m.times_reinforced = 1
+        m.last_reinforced_at = datetime.now(timezone.utc)
+        return m
+
+    def test_duplicate_detected(self):
+        existing = self._make_memory("stressor", "stressed about work", ["stressed", "work"])
+        new_fact = MemoryFact(
+            category="stressor",
+            content="stressed about work pressure",
+            keywords=["stressed", "work", "pressure"],
+            confidence=0.85,
+        )
+        result = self.svc._find_duplicate(new_fact, [existing])
+        assert result is existing
+
+    def test_different_category_not_duplicate(self):
+        existing = self._make_memory("goal", "wants better sleep", ["better", "sleep"])
+        new_fact = MemoryFact(
+            category="stressor",
+            content="stressed about sleep",
+            keywords=["stressed", "sleep"],
+            confidence=0.85,
+        )
+        result = self.svc._find_duplicate(new_fact, [existing])
+        assert result is None
+
+    def test_low_overlap_not_duplicate(self):
+        existing = self._make_memory("stressor", "stressed about money", ["stressed", "money"])
+        new_fact = MemoryFact(
+            category="stressor",
+            content="struggling with relationships",
+            keywords=["struggling", "relationships"],
+            confidence=0.80,
+        )
+        result = self.svc._find_duplicate(new_fact, [existing])
+        assert result is None
+
+
+# ── Retrieval scoring ─────────────────────────────────────────────────────────
+
+class TestRetrievalScoring:
+    svc = MemoryService()
+
+    def _make_memory(self, category, content, keywords_list, days_old=0, reinforced=1):
+        m = MagicMock()
+        m.category = category
+        m.content = content
+        m.keywords = json.dumps(keywords_list)
+        m.times_reinforced = reinforced
+        m.last_reinforced_at = datetime.now(timezone.utc) - timedelta(days=days_old)
+        return m
+
+    def test_keyword_overlap_increases_score(self):
+        mem_relevant = self._make_memory("stressor", "stressed about work", ["stressed", "work"])
+        mem_irrelevant = self._make_memory("goal", "wants better sleep", ["sleep"])
+        now = datetime.now(timezone.utc)
+        query_words = {"stressed", "work", "overwhelmed"}
+        score_rel = self.svc._score(mem_relevant, query_words, now)
+        score_irrel = self.svc._score(mem_irrelevant, query_words, now)
+        assert score_rel > score_irrel
+
+    def test_recent_memory_scores_higher(self):
+        mem_fresh = self._make_memory("stressor", "stressed about work", ["work"], days_old=0)
+        mem_old = self._make_memory("stressor", "stressed about work", ["work"], days_old=25)
+        now = datetime.now(timezone.utc)
+        query_words = {"work"}
+        score_fresh = self.svc._score(mem_fresh, query_words, now)
+        score_old = self.svc._score(mem_old, query_words, now)
+        assert score_fresh > score_old
+
+    def test_reinforced_memory_scores_higher(self):
+        mem_many = self._make_memory("coping", "walking helps", ["walking"], reinforced=5)
+        mem_once = self._make_memory("coping", "walking helps", ["walking"], reinforced=1)
+        now = datetime.now(timezone.utc)
+        query_words = set()
+        score_many = self.svc._score(mem_many, query_words, now)
+        score_once = self.svc._score(mem_once, query_words, now)
+        assert score_many > score_once
+
+
+# ── Integration: extract_from_message returns useful keywords ─────────────────
+
+class TestKeywordsOnFacts:
+    svc = MemoryService()
+
+    def test_stressor_keywords_include_subject(self):
+        facts = self.svc.extract_from_message("I'm so stressed about my relationship")
+        stressors = [f for f in facts if f.category == "stressor"]
+        assert any("relationship" in f.keywords for f in stressors)
+
+    def test_personal_context_keywords_include_occupation(self):
+        facts = self.svc.extract_from_message("I'm a doctor and it's very demanding")
+        ctx = [f for f in facts if f.category == "personal_context"]
+        assert any("doctor" in f.keywords for f in ctx)


### PR DESCRIPTION
feat: Structured memory system

  Reflect AI now remembers users across conversations. This PR implements the full memory pipeline — extraction, persistence, retrieval, and injection into
  response generation.

  What's in this PR

  New user_memories table (2b8f7a3e9c15)
  Stores per-user durable facts with category, content, a keyword index, reinforcement count, recency timestamp, and a soft-delete flag. Source message is
  linked for traceability but uses SET NULL on delete.

  MemoryService — fully implemented (was stubbed with NotImplementedError)\
  - extract_from_message(): 26 regex rules across 6 categories (stressor, coping, preference, goal, support_need, personal_context). Deterministic, no ML.
  Confidence-gated at 0.70.
  - persist_memories(): deduplication via keyword overlap (≥50% = reinforce instead of insert).
  - retrieve_memories(): scores all user memories by keyword overlap × 2 + recency × 1 + reinforcement × 0.5, returns top 5.

  Pipeline wiring (routes/conversations.py)
  Retrieval runs before ExecutionContext is built and populated into ctx.retrieved_memories. Extraction + persistence runs after generation, in the same DB
  transaction as the messages. Both are skipped entirely for CRISIS mode.

  CompanionBrain memory injection (core/brains/companion.py)
  Retrieved memories are formatted into a compact context block and appended to the mode-specific system prompt. The block instructs the model to use the
  context quietly — no "I remember you said...".

  30 unit tests (tests/test_memory.py)
  Cover extraction for all 6 categories, false-positive avoidance, deduplication logic, keyword scoring, and retrieval ranking.

  TECHNICAL.md updated
  Pipeline diagram, memory system section (categories, extraction rules, dedup, scoring, model schema), migration table, and current status all updated.

  How to test

  cd backend
  .\venv-win\Scripts\Activate.ps1
  alembic upgrade head
  python -m pytest tests/test_memory.py -v

  For an end-to-end check: start the backend, have a conversation where you mention your job or a stressor, then in a new conversation send a related
  message — the response should reflect awareness of the earlier context without explicitly referencing it.